### PR TITLE
Fix: Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A way to mitigate that is by running your command line program as an administrat
 
 For instructions on upgrading and the release notes, look on ![this page](docs/RELEASE_NOTES.md).
 
-I have a seperated doc page filled with research, notes, acknowledgements and showcases over on ![this page](docs/NOTES_AND_ACKNOWLEDGEMENTS.md).
+I have a separate doc page filled with research, notes, acknowledgements and showcases over on ![this page](docs/NOTES_AND_ACKNOWLEDGEMENTS.md).
 I will expand this document once I learn more during the development. In the meantime, you can use that knowledge to your own advantage.
 
 If you desire to connect Parrot.PY to Talon Voice, take a look at ![this page](docs/TALON_VOICE.md).


### PR DESCRIPTION
"Seperated" is not a word, but I'm unsure if the correct word is "separate" or "separated".
To me it feels more natural to say "separate".