### PR TITLE
Workaround to fix error on MacOS Ventura

### DIFF
--- a/lib/default_config.py
+++ b/lib/default_config.py
@@ -1,7 +1,15 @@
-import pyaudio
-import pyautogui
 import importlib
 import sys
+
+import pyaudio
+
+if sys.platform == "darwin":
+    # This is necessary to import before pyautogui
+    # See https://github.com/asweigart/pyautogui/issues/495#issuecomment-778241850
+    import AppKit
+
+import pyautogui
+
 pyautogui.FAILSAFE = False
 
 default_audio = pyaudio.PyAudio().get_default_input_device_info()


### PR DESCRIPTION
When I tried to run `python settings.py` on MacOS Ventura, I got the following error:

```
➜ python settings.py 
Traceback (most recent call last):
  File "settings.py", line 1, in <module>
    from config.config import *
  File "/Users/pokey/src/parrot.py/config/config.py", line 1, in <module>
    from lib.default_config import *
  File "/Users/pokey/src/parrot.py/lib/default_config.py", line 2, in <module>
    import pyautogui
  File "/Users/pokey/.pyenv/versions/parrot/lib/python3.8/site-packages/pyautogui/__init__.py", line 241, in <module>
    import mouseinfo
  File "/Users/pokey/.pyenv/versions/parrot/lib/python3.8/site-packages/mouseinfo/__init__.py", line 107, in <module>
    NSEvent = ObjCClass('NSEvent')
  File "/Users/pokey/.pyenv/versions/parrot/lib/python3.8/site-packages/rubicon/objc/api.py", line 924, in __new__
    ptr, name = cls._new_from_name(name_or_ptr)
  File "/Users/pokey/.pyenv/versions/parrot/lib/python3.8/site-packages/rubicon/objc/api.py", line 827, in _new_from_name
    raise NameError("ObjC Class '%s' couldn't be found." % name)
NameError: ObjC Class 'b'NSEvent'' couldn't be found.
```

The workaround suggested in https://github.com/asweigart/pyautogui/issues/495#issuecomment-778241850 fixed the error for me.  I have not tested this on older macs; maybe we should wrap the import in a try catch just in case?