### PR TITLE
Remove unused import causing errors

### DIFF
--- a/lib/convert_files.py
+++ b/lib/convert_files.py
@@ -8,7 +8,6 @@ from queue import *
 import numpy as np
 from scipy.fftpack import fft
 from scipy.fftpack import fftfreq
-from scipy.signal import blackmanharris
 from lib.machinelearning import get_loudest_freq, get_recording_power
 import audioop
 

--- a/lib/test_data.py
+++ b/lib/test_data.py
@@ -8,7 +8,6 @@ import audioop
 import math
 import numpy as np
 from numpy.fft import rfft
-from scipy.signal import blackmanharris
 import os
 import joblib
 import pandas as pd


### PR DESCRIPTION
Hey! Hope you don't mind the PR, but when I was running through the set up instructions for Mac when I ran into the error below. When I pulled open the solution to see if I could debug the import, I saw it was unused, so I removed it and then everything worked. Figured I'd share the fix.

![Screenshot 2024-05-09 at 7 15 50 PM](https://github.com/chaosparrot/parrot.py/assets/954453/b84b54c8-ce2a-4dd8-bc9e-32b9931eb1a0)
