### PR TITLE
fix: discrete threshold could drop below the noise floor

### DIFF
--- a/lib/stream_processing.py
+++ b/lib/stream_processing.py
@@ -341,8 +341,12 @@ def post_processing(frames: List[DetectionFrame], detection_state: DetectionStat
         detection_state.current_dBFS_threshold = detection_state.upper_bound_dBFS_threshold
 
         # Decrease the threshold by about 20% of the sound range
+        # Never below the noise floor, or every frame counts as detected
         if dominant_label_type == "discrete":
-            detection_state.current_dBFS_threshold -= detection_state.dBFS_error_margin * 3
+            detection_state.current_dBFS_threshold = max(
+                detection_state.current_dBFS_threshold - detection_state.dBFS_error_margin * 3,
+                detection_state.expected_noise_floor
+            )
 
         for index, frame in enumerate(frames):
             detected = frame.positive


### PR DESCRIPTION
`post_processing` lowers the dBFS threshold by 3x the error margin for discrete sounds. Nothing stops it landing under the noise floor, and there every frame reads as detected.

A 14.85s palate click recording:

```
noise floor   -64.92
threshold     -63.58    error margin 1.51
after drop    -68.11    3.2 dB under the floor
frames >= -68.11:  990/990
```

All frames positive, so the whole recording became one event. The p99 outlier filter then discarded it for being the only one, since `distance < percentile(distances, 99)` is false when there is a single distance. Empty `.srt`.

Downstream that surfaces as a `ZeroDivisionError` in `load_data.py:175`, dividing by a label with zero frames.

Not specific to that recording. A `pop` take from the same session escaped only by being classified continuous. Had it been discrete: -68.88, 1125/1125 frames.

Fix: clamp to `expected_noise_floor`, already carried on `DetectionState`.

| recording | before | after |
|---|---|---|
| palate, discrete | 0 events | 26 |
| pop, continuous | 49 events | 49 |

Tested on Windows, Python 3.12.

Note: existing `.v3.srt` files are not resegmented by this, since migration keys on filename. A `CURRENT_VERSION` bump would do that. Left out here, say the word if you want it folded in.
