### PR TITLE
fix: wav header declared double the real recording length

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,6 +56,14 @@ jobs:
         if: runner.os != 'Windows'
         run: pip install -r requirements-posix.txt
 
+      - name: Run the unit tests (Linux, under xvfb)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a python -m unittest discover -s tests -v
+
+      - name: Run the unit tests (Windows and macOS)
+        if: runner.os != 'Linux'
+        run: python -m unittest discover -s tests -v
+
       - name: Run the smoke test (Linux, under xvfb)
         if: runner.os == 'Linux'
         run: xvfb-run -a python tests/smoke.py

--- a/lib/stream_recorder.py
+++ b/lib/stream_recorder.py
@@ -10,6 +10,25 @@ from lib.typing import DetectionState, DetectionFrame
 from typing import List
 import io
 
+def rewrite_wav_sizes(wav_file):
+    CHUNK_SIZE_OFFSET = 4
+    DATA_SUB_CHUNK_SIZE_SIZE_OFFSET = 40
+    RIFF_PREFIX_SIZE = 8
+    WAV_HEADER_SIZE = DATA_SUB_CHUNK_SIZE_SIZE_OFFSET + 4
+    LITTLE_ENDIAN_INT = struct.Struct('<I')
+
+    wav_file.seek(0, 2)
+    file_size = wav_file.tell()
+
+    riff_chunk_size = file_size - RIFF_PREFIX_SIZE
+    wav_file.seek(CHUNK_SIZE_OFFSET)
+    wav_file.write(LITTLE_ENDIAN_INT.pack(riff_chunk_size))
+
+    data_chunk_size = file_size - WAV_HEADER_SIZE
+    wav_file.seek(DATA_SUB_CHUNK_SIZE_SIZE_OFFSET)
+    wav_file.write(LITTLE_ENDIAN_INT.pack(data_chunk_size))
+
+
 class StreamRecorder:
     total_wav_filename: str
     srt_filename: str
@@ -76,11 +95,6 @@ class StreamRecorder:
             self.persist_total_wav_file()
     
     def persist_total_wav_file(self):    
-        # This is used to modify the wave file directly
-        CHUNK_SIZE_OFFSET = 4
-        DATA_SUB_CHUNK_SIZE_SIZE_OFFSET = 40
-        LITTLE_ENDIAN_INT = struct.Struct('<I')
-    
         byteString = b''.join(self.total_audio_frames)
         self.total_audio_frames = []
         appendTotalFile = open(self.total_wav_filename, 'ab')
@@ -92,14 +106,7 @@ class StreamRecorder:
         # Which wouldn't be needed if the wave package supported appending properly                        
         # Thanks to hydrogen18.com for the explanation and code
         appendTotalFile = open(self.total_wav_filename, 'r+b')
-        appendTotalFile.seek(0,2)
-        chunk_size = appendTotalFile.tell() - 8
-        appendTotalFile.seek(CHUNK_SIZE_OFFSET)
-        appendTotalFile.write(LITTLE_ENDIAN_INT.pack(chunk_size))
-        appendTotalFile.seek(DATA_SUB_CHUNK_SIZE_SIZE_OFFSET)
-        sample_length = 2 * ( self.index * self.length_per_frame )
-        
-        appendTotalFile.write(LITTLE_ENDIAN_INT.pack(sample_length))
+        rewrite_wav_sizes(appendTotalFile)
         appendTotalFile.close()
 
     # Resume playing
@@ -153,17 +160,7 @@ class StreamRecorder:
                 f.truncate()
                 
                 # Overwrite the total recording length
-                CHUNK_SIZE_OFFSET = 4
-                DATA_SUB_CHUNK_SIZE_SIZE_OFFSET = 40
-                LITTLE_ENDIAN_INT = struct.Struct('<I')
-
-                f.seek(0,2)
-                chunk_size = f.tell() - 8
-                f.seek(CHUNK_SIZE_OFFSET)
-                f.write(LITTLE_ENDIAN_INT.pack(chunk_size))
-                f.seek(DATA_SUB_CHUNK_SIZE_SIZE_OFFSET)
-                sample_length = 2 * ( self.index * self.length_per_frame )
-                f.write(LITTLE_ENDIAN_INT.pack(sample_length))        
+                rewrite_wav_sizes(f)
         
         return should_resume
     

--- a/tests/test_stream_recorder.py
+++ b/tests/test_stream_recorder.py
@@ -1,0 +1,102 @@
+"""The recorder patches the wav header itself while streaming, since the wave
+module only writes one on close. Both write sites, append and truncate."""
+import math
+import os
+import shutil
+import struct
+import sys
+import tempfile
+import types
+import unittest
+import wave
+
+ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+import config.config
+from lib.stream_recorder import StreamRecorder
+from lib.typing import DetectionState, DetectionLabel
+
+# One callback frame: RATE * RECORD_SECONDS / SLIDING_WINDOW_AMOUNT samples, 2 bytes each
+FRAME_BYTES = round(config.config.RATE * config.config.RECORD_SECONDS
+                    / config.config.SLIDING_WINDOW_AMOUNT) * 2
+MS_PER_FRAME = math.floor(config.config.RECORD_SECONDS
+                          / config.config.SLIDING_WINDOW_AMOUNT * 1000)
+FRAMES_WRITTEN = 15
+WAV_HEADER_SIZE = 44
+
+
+class SampleWidthOnly:
+    # The recorder only asks the audio interface how wide a sample is
+    def get_sample_size(self, audio_format):
+        return 2   # paInt16
+
+
+class StoppableStream:
+    def start_stream(self):
+        pass
+
+    def stop_stream(self):
+        pass
+
+
+def declared_frames(path):
+    with wave.open(path, "rb") as handle:
+        return handle.getnframes()
+
+
+def declared_riff_size(path):
+    # The wave module never reads this one back against the file length
+    with open(path, "rb") as handle:
+        handle.seek(4)
+        return struct.unpack("<I", handle.read(4))[0]
+
+
+class WavHeaderTest(unittest.TestCase):
+    def setUp(self):
+        workdir = tempfile.mkdtemp(prefix="parrot_header_")
+        self.addCleanup(shutil.rmtree, workdir, True)
+        self.wav_file = os.path.join(workdir, "total.wav")
+
+        label = DetectionLabel("pop", 0, 0, "", 0, 0, 0, 0, 0)
+        state = DetectionState("strategy", "recording", MS_PER_FRAME, 0, False,
+                               0, 0, 0, 0, [label])
+        self.recorder = StreamRecorder(
+            SampleWidthOnly(), StoppableStream(), self.wav_file,
+            os.path.join(workdir, "total.v%d.srt" % config.config.CURRENT_VERSION),
+            state)
+        self.recorder.total_audio_frames = [b"\0" * FRAME_BYTES] * FRAMES_WRITTEN
+        self.recorder.index = FRAMES_WRITTEN
+        self.recorder.length_per_frame = FRAME_BYTES
+        self.recorder.detection_frames = [types.SimpleNamespace(label="silence")
+                                          for _ in range(FRAMES_WRITTEN)]
+        self.recorder.persist_total_wav_file()
+
+        self.written_bytes = FRAME_BYTES * FRAMES_WRITTEN
+
+    def test_header_counts_the_samples_the_file_holds(self):
+        self.assertEqual(declared_frames(self.wav_file), self.written_bytes // 2)
+
+    def test_file_is_a_canonical_header_and_its_data(self):
+        self.assertEqual(os.path.getsize(self.wav_file),
+                         WAV_HEADER_SIZE + self.written_bytes)
+
+    def test_riff_size_counts_everything_after_it(self):
+        self.assertEqual(declared_riff_size(self.wav_file),
+                         os.path.getsize(self.wav_file) - 8)
+
+    def test_header_still_matches_after_clearing_the_last_seconds(self):
+        removed = 5
+        self.recorder.clear(removed * MS_PER_FRAME / 1000)
+
+        kept_bytes = FRAME_BYTES * (FRAMES_WRITTEN - removed)
+        self.assertEqual(os.path.getsize(self.wav_file),
+                         WAV_HEADER_SIZE + kept_bytes)
+        self.assertEqual(declared_frames(self.wav_file), kept_bytes // 2)
+        self.assertEqual(declared_riff_size(self.wav_file),
+                         os.path.getsize(self.wav_file) - 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Existing bug since 2022 - wav headers declared double length. 

This wasn't resulting in any bugs today - playback and viewing the file usually looked fine with modern programs like audacity, most wav players, but the actual header was double

Found this when implementing GUI features like "fit to view" or continuing recording on an existing file after trimming it.

## Testing
This is a terminal/pwsh python script representing old vs new code

```pwsh
# pwsh
@'
import shutil, struct, tempfile, wave, os

RATE, WIDTH, CHANNELS = 15000, 2, 1
FRAMES, LENGTH_PER_FRAME = 15, 2000
AUDIO = b"\0" * (FRAMES * LENGTH_PER_FRAME)
LITTLE_ENDIAN_INT = struct.Struct("<I")

tmp = tempfile.mkdtemp()
base = os.path.join(tmp, "base.wav")
w = wave.open(base, "wb")
w.setnchannels(CHANNELS); w.setsampwidth(WIDTH); w.setframerate(RATE); w.close()
with open(base, "ab") as f:
    f.write(AUDIO)

def old(path, index, length_per_frame):
    with open(path, "r+b") as f:
        f.seek(0, 2)
        f.seek(4);  f.write(LITTLE_ENDIAN_INT.pack(os.path.getsize(path) - 8))
        f.seek(40); f.write(LITTLE_ENDIAN_INT.pack(2 * (index * length_per_frame)))

def new(path):
    with open(path, "r+b") as f:
        f.seek(0, 2)
        file_size = f.tell()
        f.seek(4);  f.write(LITTLE_ENDIAN_INT.pack(file_size - 8))
        f.seek(40); f.write(LITTLE_ENDIAN_INT.pack(file_size - 44))

print("created %s" % tmp)
print()
for name, apply in (("BEFORE", lambda p: old(p, FRAMES, LENGTH_PER_FRAME)),
                    ("AFTER",  new)):
    path = os.path.join(tmp, name + ".wav")
    shutil.copy(base, path)
    apply(path)
    h = wave.open(path, "rb")
    print("%-7s header says %5d frames / %.2f s   file holds %5d frames / %.2f s"
          % (name, h.getnframes(), h.getnframes() / RATE,
             len(AUDIO) // (WIDTH * CHANNELS), len(AUDIO) / (WIDTH * CHANNELS) / RATE))
'@ | python -
```

Result:
```
BEFORE  header says 30000 frames / 2.00 s   file holds 15000 frames / 1.00 s
AFTER   header says 15000 frames / 1.00 s   file holds 15000 frames / 1.00 s
```