### PR TITLE
Migrate pyaudio -> sounddevice

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,16 +30,13 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-*.txt
 
-      # portaudio builds pyaudio, xvfb is for the pyautogui import.
+      # sounddevice needs portaudio at run time, xvfb is for the pyautogui
+      # import. The wheel carries portaudio on Windows and macOS, not on Linux.
       - name: Install system libraries (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libasound2-dev xvfb
-
-      - name: Install system libraries (macOS)
-        if: runner.os == 'macOS'
-        run: brew install portaudio
+          sudo apt-get install -y libportaudio2 xvfb
 
       # The torch on PyPI is the CUDA build here, ~2.5 GB of nvidia wheels.
       # Only sticks while requirements-posix.txt asks for a torch this one

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Python packages such as
 * pandas 
 * matplotlib *( for the graphing of test results )*
 * scikit-learn *( for the machine learning bits )*
-* pyaudio *( audio recording and playing )*
+* sounddevice *( audio recording and playing )*
 * python_speech_features *( for audio manipulation, specifically the MFCC algorithm )*
 * pyautogui *( for mouse and keyboard simulation )*
 * pydirectinput *( for mouse and keyboard simulation, but with DirectX keycodes instead )*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It's name is inspired by the way parrots and parakeets communicate, using chirps
 
 # Software requirements
 * Windows version 7 and up, MacOS or Linux (X11)
-* Python 3.8 (64 bit)
+* Python 3.12 (64 bit)
 * Project IRIS ( OPTIONAL - Used for turning the eyetracker into a mouse cursor )
 
 Python packages such as

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,7 +3,7 @@
 
 This guide focuses on Windows installation.  See also [Mac installation](./MAC_INSTALLATION.md) and [Linux installation](./LINUX_INSTALLATION.md) for some platform-specific help
 
-For this program to work, you must atleast have access to a microphone and a machine that can run Python 3.8 64 bit.
+For this program to work, you must atleast have access to a microphone and a machine that can run Python 3.12 64 bit.
 This document describes installing the program on a Windows machine.
 
 If you want to install on a Mac, steps 1 to 3 can be found here: [Mac installation guide](MAC_INSTALLATION.md).

--- a/docs/LINUX_INSTALLATION.md
+++ b/docs/LINUX_INSTALLATION.md
@@ -7,7 +7,7 @@ Step one - Installing required programs
 Open up a terminal and see if python is installed by running the following snippet ```python --version```. If it shows 3.12, you're good to go!
 Otherwise you can install python using your local package manager, make sure you install 3.12, as some libraries don't work well with 3.9 yet.
 
-The two dependencies that I needed to install on Linux for my testdrive were 'TK' and 'portaudio'. 
+The two dependencies that I needed to install on Linux for my testdrive were 'TK' and 'portaudio' ( `libportaudio2` on Debian and Ubuntu ). Linux is the only platform that needs it installed separately: the sounddevice wheel carries its own copy on Windows and MacOS. 
 
 Step two - Download and extract the zipfile from this github repository
 ---------------

--- a/docs/MAC_INSTALLATION.md
+++ b/docs/MAC_INSTALLATION.md
@@ -11,18 +11,16 @@ brew --version
 
 If it isn't returning a version, you need to install it. Follow the instructions here: [Homebrew installation](https://docs.brew.sh/Installation)
 
-After you have installed homebrew, you need to install Python 3.8 and portaudio. This can be done using the following commands
+After you have installed homebrew, you need to install Python 3.8. This can be done using the following commands
 
 ```
 brew install python@3.12
-brew install portaudio
 brew install six
 ```
 
 Test if your python version is correct by typing ```python --version``` in your Terminal, if it shows 3.12, you're good to go!
 
-On the M1, some issues can occur while installing portaudio. There are a number of possible fixes that are outlined in these links:
-- [Unable to install pyaudio on M1 Mac](https://stackoverflow.com/questions/68251169/unable-to-install-pyaudio-on-m1-mac-portaudio-already-installed)
+On the M1, some libraries can fail to build. A possible fix is outlined here:
 - [MacOS Brew install libsndfile but still not found](https://stackoverflow.com/questions/70737503/macos-brew-install-libsndfile-but-still-not-found)
 
 Step two - Download and extract the zipfile from this github repository

--- a/docs/MAC_INSTALLATION.md
+++ b/docs/MAC_INSTALLATION.md
@@ -11,7 +11,7 @@ brew --version
 
 If it isn't returning a version, you need to install it. Follow the instructions here: [Homebrew installation](https://docs.brew.sh/Installation)
 
-After you have installed homebrew, you need to install Python 3.8. This can be done using the following commands
+After you have installed homebrew, you need to install Python 3.12. This can be done using the following commands
 
 ```
 brew install python@3.12

--- a/lib/audio_input.py
+++ b/lib/audio_input.py
@@ -1,14 +1,19 @@
+import sounddevice as sd
+
 from config.config import FORMAT
 
 def open_input_stream(
-        audio, device_index, *, rate, channels, record_seconds,
+        device_index, *, rate, channels, record_seconds,
         sliding_window_amount, callback=None):
-    """Open a microphone stream, for recording, listening or probing a device."""
-    return audio.open(
-        format=FORMAT,
+    """Open a microphone stream, for recording, listening or probing a device.
+
+    The stream comes back stopped. Every caller starts its own, once whatever
+    consumes the frames is ready for them.
+    """
+    return sd.InputStream(
+        dtype=FORMAT,
         channels=channels,
-        rate=rate,
-        input=True,
-        input_device_index=device_index,
-        frames_per_buffer=round(rate * record_seconds / sliding_window_amount),
-        stream_callback=callback)
+        samplerate=rate,
+        device=device_index,
+        blocksize=round(rate * record_seconds / sliding_window_amount),
+        callback=callback)

--- a/lib/default_config.py
+++ b/lib/default_config.py
@@ -1,7 +1,21 @@
 from importlib.util import find_spec
 import sys
 
-import pyaudio
+import numpy as np
+
+try:
+    import sounddevice as sd
+except ImportError:
+    raise SystemExit(
+        "Parrot records audio through sounddevice.\n"
+        "Update your environment with: pip install -r requirements-" +
+        ("windows" if sys.platform == "win32" else "posix") + ".txt")
+except OSError as error:
+    # sounddevice needs PortAudio itself at run time. Its wheel carries a copy
+    # on Windows and macOS, so only Linux can arrive here.
+    raise SystemExit(
+        "sounddevice could not load PortAudio: " + str(error) + "\n"
+        "On Debian and Ubuntu: sudo apt-get install libportaudio2")
 
 if sys.platform == "darwin":
     # This is necessary to import before pyautogui
@@ -13,16 +27,16 @@ import pyautogui
 pyautogui.FAILSAFE = False
 
 try:
-    default_audio = pyaudio.PyAudio().get_default_input_device_info()
-except OSError:
+    default_audio = sd.query_devices(kind="input")
+except (sd.PortAudioError, ValueError):
     default_audio = None
 
 REPEAT_DELAY = 0.5
 REPEAT_RATE = 33
 SPEECHREC_ENABLED = False
 
-FORMAT = pyaudio.paInt16
-SAMPLE_WIDTH = pyaudio.get_sample_size(FORMAT)
+FORMAT = "int16"
+SAMPLE_WIDTH = np.dtype(FORMAT).itemsize
 CHANNELS = 1
 RATE = 16000
 CHUNK = 1024

--- a/lib/listen.py
+++ b/lib/listen.py
@@ -1,7 +1,7 @@
 import numpy as np
 from config.config import *
 from lib.machinelearning import feature_engineering, feature_engineering_raw, get_label_for_directory, get_highest_intensity_of_wav_file, get_recording_power
-import pyaudio
+import sounddevice as sd
 import wave
 import time
 import scipy
@@ -118,7 +118,7 @@ def action_consumer( stream, classifier, dataDicts, persist_replay, replay_file,
         print( "----------- ERROR DURING CONSUMING ACTIONS -------------- " )
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb)
-        listening_state['stream'].stop_stream()
+        listening_state['stream'].stop()
         listening_state['currently_recording'] = False
 
     
@@ -165,15 +165,13 @@ def classification_consumer( stream, classifier, persist_files, high_speed ):
         print( "----------- ERROR DURING AUDIO CLASSIFICATION -------------- " )
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb)
-        listening_state['stream'].stop_stream()
+        listening_state['stream'].stop()
         listening_state['currently_recording'] = False
     
     
-def nonblocking_record( in_data, frame_count, time_info, status ):
+def nonblocking_record( indata, frames, time_info, status ):
     global listening_state
-    listening_state['audioQueue'].put( in_data )
-    
-    return in_data, pyaudio.paContinue
+    listening_state['audioQueue'].put( indata.tobytes() )
     
 def start_nonblocking_listen_loop( classifier, mode_switcher = False, persist_replay = False, persist_files = False, amount_of_seconds=-1, high_speed=False ):
     global listening_state
@@ -200,8 +198,7 @@ def start_nonblocking_listen_loop( classifier, mode_switcher = False, persist_re
     replay_file = REPLAYS_FOLDER + "/replay_" + str(int(starttime)) + ".csv"
     
     infinite_duration = amount_of_seconds == -1
-    audio = pyaudio.PyAudio()
-    if ( validate_microphone_input(audio) == False ):
+    if ( validate_microphone_input() == False ):
         return None
     
     if( infinite_duration ):
@@ -210,7 +207,7 @@ def start_nonblocking_listen_loop( classifier, mode_switcher = False, persist_re
         print ( "Listening for " + str( amount_of_seconds ) + " seconds..." )
     print ( "" )
     
-    listening_state['stream'] = open_input_stream(audio, INPUT_DEVICE_INDEX,
+    listening_state['stream'] = open_input_stream(INPUT_DEVICE_INDEX,
         rate=classifier.get_setting('RATE', RATE),
         channels=classifier.get_setting('CHANNELS', CHANNELS),
         record_seconds=classifier.get_setting('RECORD_SECONDS', RECORD_SECONDS),
@@ -226,7 +223,7 @@ def start_nonblocking_listen_loop( classifier, mode_switcher = False, persist_re
     actionConsumer.start()
     
     listening_state['last_audio_update'] = time.time()
-    listening_state['stream'].start_stream()
+    listening_state['stream'].start()
     ipc_manager.setParrotState("running")
 
     while listening_state['currently_recording'] == True and listening_state['restart_listen_loop'] == False:
@@ -238,9 +235,8 @@ def start_nonblocking_listen_loop( classifier, mode_switcher = False, persist_re
         time.sleep(STATE_POLLING_THRESHOLD)
 
     # Stop all the streams and different threads
-    listening_state['stream'].stop_stream()
+    listening_state['stream'].stop()
     listening_state['stream'].close()
-    audio.terminate()
     listening_state['audioQueue'].queue.clear()
     listening_state['classifierQueue'].queue.clear()
     classificationConsumer.join()
@@ -374,15 +370,15 @@ def load_running_classifier( classifier_name ):
     return classifier
     
 # Validate and print the currently used microphone
-def validate_microphone_input( audio ):
+def validate_microphone_input():
     try:
-        micDict = audio.get_device_info_by_index( INPUT_DEVICE_INDEX )
-        if (micDict and micDict['maxInputChannels'] > 0):
+        micDict = sd.query_devices( INPUT_DEVICE_INDEX )
+        if (micDict and micDict['max_input_channels'] > 0):
             print( "Using input from " + micDict['name'] )
             return True
         else:
             raise IOError( "Invalid number of channels" )
-    except IOError as e:
+    except (IOError, sd.PortAudioError) as e:
         print( "------ ERROR - NO VALID MICROPHONE FOUND DURING START UP ------ " )
         print( "Make sure your microphone is connected before starting up Parrot" )
         print( "or change the INPUT_DEVICE_INDEX in the config/config.py file.")

--- a/lib/record_data.py
+++ b/lib/record_data.py
@@ -1,5 +1,5 @@
 from config.config import *
-import pyaudio
+import sounddevice as sd
 import time
 import math
 import os
@@ -160,8 +160,6 @@ def record_controls( key_poller, recordQueue=None ):
     return True    
     
 def record_sound():
-    audio = pyaudio.PyAudio()
-
     print( "-------------------------" )
     print( "Let's record some sounds!")
     print( "This script is going to listen to your microphone input" )
@@ -212,11 +210,10 @@ def record_sound():
     # Note - this assumes a maximum of 10 possible input devices, which is probably wrong but eh
     print("What microphone do you want to record with? ( Empty is the default system mic, [X] exits the recording menu )")
     print("You can put a space in between numbers to record with multiple microphones")
-    for index in range(audio.get_device_count()):
-        device_info = audio.get_device_info_by_index(index)
-        if (device_info and device_info['name'] and device_info['maxInputChannels'] > 0):
+    for index, device_info in enumerate(sd.query_devices()):
+        if (device_info and device_info['name'] and device_info['max_input_channels'] > 0):
             default_mic = " - " if index != INPUT_DEVICE_INDEX else " DEFAULT - "
-            host_api = audio.get_host_api_info_by_index(device_info['hostApi'])
+            host_api = sd.query_hostapis(device_info['hostapi'])
             host_api_string = " " + host_api["name"] if host_api else ""
             print("[" + str(index) + "]" + default_mic + device_info['name'] + host_api_string)
                 
@@ -230,7 +227,7 @@ def record_sound():
         mic_indecis = mic_index_string.split()
     valid_mics = []
     for mic_index in mic_indecis:
-        if (str.isdigit(mic_index) and validate_microphone_index(audio, int(mic_index))):
+        if (str.isdigit(mic_index) and validate_microphone_index(int(mic_index))):
             valid_mics.append(int(mic_index))
     
     if len(valid_mics) == 0:
@@ -336,10 +333,8 @@ def record_consumer(labels, FULL_WAVE_OUTPUT_FILENAME, SRT_FILE, MICROPHONE_INPU
         traceback.print_exception(exc_type, exc_value, exc_tb)
         currently_recording = -1
 
-def multithreaded_record( in_data, frame_count, time_info, status, queue ):
-    queue.put( in_data )
-    
-    return in_data, pyaudio.paContinue
+def multithreaded_record( indata, frames, time_info, status, queue ):
+    queue.put( indata.tobytes() )
                 
 # Records a non blocking audio stream and saves the source and SRT file for it
 def non_blocking_record(labels, FULL_WAVE_OUTPUT_FILENAME, SRT_FILE, MICROPHONE_INPUT_INDEX, print_logs):
@@ -349,7 +344,7 @@ def non_blocking_record(labels, FULL_WAVE_OUTPUT_FILENAME, SRT_FILE, MICROPHONE_
     mic_index = 'index' + str(MICROPHONE_INPUT_INDEX)
 
     recordQueue[mic_index] = Queue(maxsize=0)
-    micindexed_lambda = lambda in_data, frame_count, time_info, status, queue=recordQueue[mic_index]: multithreaded_record(in_data, frame_count, time_info, status, queue)
+    micindexed_lambda = lambda indata, frames, time_info, status, queue=recordQueue[mic_index]: multithreaded_record(indata, frames, time_info, status, queue)
     
     detection_strategy = CURRENT_DETECTION_STRATEGY
     ms_per_frame = math.floor(RECORD_SECONDS / SLIDING_WINDOW_AMOUNT * 1000)
@@ -357,11 +352,8 @@ def non_blocking_record(labels, FULL_WAVE_OUTPUT_FILENAME, SRT_FILE, MICROPHONE_
     for label in list(labels.keys()):
         detection_labels.append(DetectionLabel(label, 0, labels[label], "", 0, 0, 0, 0, 0))
     
-    audio = pyaudio.PyAudio()
-
     recorders[mic_index] = StreamRecorder(
-        audio,
-        open_input_stream(audio, MICROPHONE_INPUT_INDEX,
+        open_input_stream(MICROPHONE_INPUT_INDEX,
             rate=RATE, channels=CHANNELS, record_seconds=RECORD_SECONDS,
             sliding_window_amount=SLIDING_WINDOW_AMOUNT, callback=micindexed_lambda),
         FULL_WAVE_OUTPUT_FILENAME,
@@ -380,17 +372,17 @@ def print_status(detection_state: DetectionState, extra_states: List[DetectionSt
     for line in current_status:
         print( line )
 
-def validate_microphone_index(audio, input_index):
+def validate_microphone_index(input_index):
     micDict = {'name': 'Missing Microphone index ' + str(input_index)}
     try:
-        micDict = audio.get_device_info_by_index( input_index )
-        if (micDict and micDict['maxInputChannels'] > 0):            
-            host_api = audio.get_host_api_info_by_index(micDict['hostApi'])
+        micDict = sd.query_devices( input_index )
+        if (micDict and micDict['max_input_channels'] > 0):            
+            host_api = sd.query_hostapis(micDict['hostapi'])
             host_api_string = " " + host_api["name"] if host_api else ""
             print( "Using input from " + micDict['name'] + host_api_string )
             return True
         else:
             raise IOError( "Invalid number of channels" )
-    except IOError as e:
+    except (IOError, sd.PortAudioError) as e:
         print("Could not connect enough audio channels to " + micDict['name'] + ", disabling this mic for recording")
         return False

--- a/lib/stream_controls.py
+++ b/lib/stream_controls.py
@@ -1,6 +1,6 @@
 import numpy as np
 from config.config import *
-import pyaudio
+import sounddevice as sd
 import time
 from queue import *
 import lib.ipc_manager as ipc_manager
@@ -48,7 +48,7 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
     # Any state can transition to switch and then transition back
     if (requested_state == "switching" or requested_state == "switch_and_run"):
         if (listening_state['stream']):
-            listening_state['stream'].stop_stream()
+            listening_state['stream'].stop()
         if( listening_state['audioQueue'] != None ):
             listening_state['audioQueue'].queue.clear()
         
@@ -58,7 +58,7 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
             print( "Listening stopped" )
             print( "-----------------" )
             listening_state['classifier_name'] = ipc_manager.getClassifier()            
-            listening_state['stream'].stop_stream()
+            listening_state['stream'].stop()
             set_loop_state(current_state)
             
             # Reset the stream
@@ -72,10 +72,10 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
         elif( requested_state == "paused"):
             print( "Listening paused!" )
             if (listening_state['stream']):
-                listening_state['stream'].stop_stream()
+                listening_state['stream'].stop()
         elif ( requested_state == "disconnected" ):
             if (listening_state['stream']):
-                listening_state['stream'].stop_stream()
+                listening_state['stream'].stop()
             if( listening_state['audioQueue'] != None ):
                 listening_state['audioQueue'].queue.clear()
             print( "Found a stall in audio updates" )
@@ -85,17 +85,20 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
     if (current_state == "disconnected"):
         global poll_counter
         if (requested_state == False):
-            audio = pyaudio.PyAudio()
             try:
-                stream = open_input_stream(audio, INPUT_DEVICE_INDEX,
+                stream = open_input_stream(INPUT_DEVICE_INDEX,
                     rate=RATE, channels=CHANNELS, record_seconds=RECORD_SECONDS,
                     sliding_window_amount=SLIDING_WINDOW_AMOUNT)
-                print( "" )
-                print( "Did not receive errors during reconnection to mic, restarting stream" )
-                if ( stream is not None ):
-                    stream.stop_stream()
+
+                # An InputStream does not touch the device until it starts,
+                # so the probe starts it to find out whether the mic is back.
+                # Closing in a finally, since this runs on every attempt.
+                try:
+                    stream.start()
+                    print( "" )
+                    print( "Did not receive errors during reconnection to mic, restarting stream" )
+                finally:
                     stream.close()
-                    audio.terminate()
                     
                 # Reset the stream
                 listening_state['restart_listen_loop'] = True
@@ -103,7 +106,6 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
                 return LOOP_STATE_BREAK
             except Exception as e:
                 poll_counter = poll_counter + 1
-                audio.terminate()
                 print( "Reconnection attempt " + str( poll_counter ) + "...", end="\r")
         elif (requested_state == "paused"):
             print( "" )
@@ -119,10 +121,10 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
             print( "Listening resumed!" )
             if (listening_state['stream']):
                 try:
-                    listening_state['stream'].start_stream()
+                    listening_state['stream'].start()
                     set_loop_state(requested_state)                    
                     return LOOP_STATE_CONTINUE                    
-                except IOError as e:
+                except (IOError, sd.PortAudioError) as e:
                     print( "An error occured during the resuming of the listening")
                     return LOOP_STATE_CONTINUE
     

--- a/lib/stream_controls.py
+++ b/lib/stream_controls.py
@@ -90,9 +90,7 @@ def transition_state(listening_state, modeSwitcher, current_state, requested_sta
                     rate=RATE, channels=CHANNELS, record_seconds=RECORD_SECONDS,
                     sliding_window_amount=SLIDING_WINDOW_AMOUNT)
 
-                # An InputStream does not touch the device until it starts,
-                # so the probe starts it to find out whether the mic is back.
-                # Closing in a finally, since this runs on every attempt.
+                # Start the stream to probe the mic, then close.
                 try:
                     stream.start()
                     print( "" )

--- a/lib/stream_recorder.py
+++ b/lib/stream_recorder.py
@@ -1,5 +1,5 @@
 from config.config import *
-import pyaudio
+import sounddevice as sd
 import struct
 import wave
 import math
@@ -35,8 +35,7 @@ class StreamRecorder:
     thresholds_filename: str
     comparison_wav_filename: str
     
-    audio: pyaudio.PyAudio
-    stream: pyaudio.Stream
+    stream: sd.InputStream
     detection_state: DetectionState
     
     length_per_frame: int
@@ -47,13 +46,12 @@ class StreamRecorder:
     current_occurrence: List[DetectionFrame]
     false_occurrence: List[DetectionFrame]
     
-    def __init__(self, audio: pyaudio.PyAudio, stream: pyaudio.Stream, total_wav_filename: str, srt_filename: str, detection_state: DetectionState):
+    def __init__(self, stream: sd.InputStream, total_wav_filename: str, srt_filename: str, detection_state: DetectionState):
         self.total_wav_filename = total_wav_filename
         self.srt_filename = srt_filename
         self.comparison_wav_filename = srt_filename.replace(".v" + str(CURRENT_VERSION) + ".srt", "_comparison.wav")
         self.thresholds_filename = srt_filename.replace(".v" + str(CURRENT_VERSION) + ".srt", "_thresholds.txt")
         
-        self.audio = audio
         self.stream = stream
         self.detection_state = detection_state
         self.total_audio_frames = []
@@ -111,10 +109,10 @@ class StreamRecorder:
 
     # Resume playing
     def resume(self):
-        self.stream.start_stream()
+        self.stream.start()
     
     def pause(self):
-        self.stream.stop_stream()
+        self.stream.stop()
         
         self.index -= len(self.total_audio_frames)
         if self.index != 0 and len(self.total_audio_frames) > 0:
@@ -188,7 +186,6 @@ class StreamRecorder:
         comparison_wav_file.setframerate(RATE)
         post_processing(self.detection_frames, self.detection_state, self.srt_filename, self.thresholds_filename, callback, comparison_wav_file)
         self.stream.close()
-        self.audio.terminate()
         self.detection_frames = []
 
     # Do all post processing related tasks that cannot be done during runtime

--- a/lib/test_data.py
+++ b/lib/test_data.py
@@ -1,5 +1,5 @@
 from config.config import *
-import pyaudio
+import sounddevice as sd
 import wave
 import time
 from time import sleep
@@ -12,7 +12,7 @@ import os
 import joblib
 import pandas as pd
 import matplotlib.pyplot as plt
-import pyaudio
+import sounddevice as sd
 from lib.listen import start_nonblocking_listen_loop, predict_wav_files, validate_microphone_input
 from lib.machinelearning import feature_engineering
 import csv
@@ -171,8 +171,7 @@ def audio_analysis( available_models ):
         new_or_existing = input("")
     
     if( new_or_existing.lower() == "n" ):
-        audio = pyaudio.PyAudio()
-        if (validate_microphone_input(audio) == False):
+        if (validate_microphone_input() == False):
             return
     
         for wav_file in wav_files:

--- a/requirements-posix.txt
+++ b/requirements-posix.txt
@@ -1,4 +1,4 @@
-pyaudio
+sounddevice
 numpy
 pandas
 matplotlib

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,4 +1,4 @@
-pyaudio
+sounddevice
 numpy
 pandas
 numba

--- a/tests/test_audio_input.py
+++ b/tests/test_audio_input.py
@@ -23,7 +23,10 @@ ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, ROOT)
 os.chdir(ROOT)
 
-import pyaudio
+import numpy as np
+import sounddevice as sd
+from unittest import mock
+
 import lib.listen
 # The shipped defaults, not config.config: that one execs the user's own
 # config.py over the top, and setting your own RATE should not fail a test about
@@ -46,33 +49,33 @@ MISSING = object()
 
 def library_frame(pcm):
     """16 bit PCM as the library hands it to a callback."""
-    return pcm
+    return np.frombuffer(pcm, dtype=np.int16).reshape(-1, 1)
 
 
 def keep_going(frame):
     """What a callback returns to leave the stream running."""
-    return frame, pyaudio.paContinue
+    return None
 
 
 def device(name, input_channels):
     """A device row as the library reports it."""
-    return {"name": name, "maxInputChannels": input_channels, "hostApi": 0}
+    return {"name": name, "max_input_channels": input_channels, "hostapi": 0}
 
 
 def stream_settings(kwargs):
     """An open call in plain values, whatever the library names them."""
     return {
-        "rate": kwargs["rate"],
+        "rate": kwargs["samplerate"],
         "channels": kwargs["channels"],
-        "sample_width": pyaudio.get_sample_size(kwargs["format"]),
-        "frame_samples": kwargs["frames_per_buffer"],
-        "device": kwargs["input_device_index"],
+        "sample_width": np.dtype(kwargs["dtype"]).itemsize,
+        "frame_samples": kwargs["blocksize"],
+        "device": kwargs["device"],
     }
 
 
-# Raised for a device index that is not there. sounddevice raises
-# PortAudioError, which is not an OSError, so `except IOError` would miss it.
-NO_SUCH_DEVICE = IOError
+# Raised for a device index that is not there. PortAudioError is not an
+# OSError, so `except IOError` alone would miss it.
+NO_SUCH_DEVICE = sd.PortAudioError
 
 MIC = device("Fake mic", 1)
 SPEAKERS = device("Fake speakers", 0)
@@ -80,36 +83,42 @@ HOST_API = {"name": "Fake host API"}
 
 
 class DeviceTable:
-    """pyaudio.PyAudio(), as far as the probes use it."""
+    """The library's device list, as far as the probes read it."""
 
     def __init__(self, devices):
         self.devices = devices
 
-    def get_device_info_by_index(self, index):
+    def query_devices(self, index):
         if index not in self.devices:
             raise NO_SUCH_DEVICE("Invalid device index")
         return self.devices[index]
 
-    def get_host_api_info_by_index(self, index):
+    def query_hostapis(self, index):
         return HOST_API
+
+
+def listing(devices):
+    """The probes read the library's module level table, so it is patched."""
+    table = DeviceTable(devices)
+    return mock.patch.multiple(sd, query_devices=table.query_devices,
+                               query_hostapis=table.query_hostapis)
 
 
 class OpenedStream:
     def __init__(self):
         self.running = False
 
-    def start_stream(self):
+    def start(self):
         self.running = True
 
 
-class RecordingLibrary(DeviceTable):
+class RecordingLibrary:
     """Remembers what a stream was opened for instead of opening one."""
 
     def __init__(self):
-        super().__init__({})
         self.opened = {}
 
-    def open(self, **kwargs):
+    def __call__(self, **kwargs):
         self.opened.update(kwargs)
         return OpenedStream()
 
@@ -121,19 +130,22 @@ def quietly(function, *arguments):
 
 
 def probe_index(devices, index):
-    return quietly(validate_microphone_index, DeviceTable(devices), index)
+    with listing(devices):
+        return quietly(validate_microphone_index, index)
 
 
 def probe_configured_input(devices):
-    return quietly(validate_microphone_input, DeviceTable(devices))
+    with listing(devices):
+        return quietly(validate_microphone_input)
 
 
 def open_a_stream(rate=RATE, channels=CHANNELS, seconds=RECORD_SECONDS,
                   sliding_window=SLIDING_WINDOW_AMOUNT):
     """What the library was asked for, and the stream it gave back."""
     library = RecordingLibrary()
-    stream = open_input_stream(library, MIC_INDEX, rate=rate, channels=channels,
-                               record_seconds=seconds, sliding_window_amount=sliding_window)
+    with mock.patch.object(sd, "InputStream", library):
+        stream = open_input_stream(MIC_INDEX, rate=rate, channels=channels,
+                                   record_seconds=seconds, sliding_window_amount=sliding_window)
     return stream_settings(library.opened), stream
 
 
@@ -233,9 +245,9 @@ class StreamSettingsTest(unittest.TestCase):
         self.assertEqual(settings["frame_samples"], 960)
 
     def test_the_helper_does_not_start_the_stream(self):
-        # Nobody notices today, since pyaudio's open starts it anyway. Starting
-        # here would move when frames begin for the record and listen paths,
-        # which wait for their consumer threads first.
+        # Every caller starts its own. Starting here would move when frames
+        # begin for the record and listen paths, which wait for their consumer
+        # threads first.
         _, stream = open_a_stream()
 
         self.assertFalse(stream.running)

--- a/tests/test_stream_recorder.py
+++ b/tests/test_stream_recorder.py
@@ -27,16 +27,11 @@ FRAMES_WRITTEN = 15
 WAV_HEADER_SIZE = 44
 
 
-class UnusedAudio:
-    # The recorder only holds this to terminate() it, which these tests never do
-    pass
-
-
 class StoppableStream:
-    def start_stream(self):
+    def start(self):
         pass
 
-    def stop_stream(self):
+    def stop(self):
         pass
 
 
@@ -62,7 +57,7 @@ class WavHeaderTest(unittest.TestCase):
         state = DetectionState("strategy", "recording", MS_PER_FRAME, 0, False,
                                0, 0, 0, 0, [label])
         self.recorder = StreamRecorder(
-            UnusedAudio(), StoppableStream(), self.wav_file,
+            StoppableStream(), self.wav_file,
             os.path.join(workdir, "total.v%d.srt" % config.config.CURRENT_VERSION),
             state)
         self.recorder.total_audio_frames = [b"\0" * FRAME_BYTES] * FRAMES_WRITTEN


### PR DESCRIPTION
**Why sounddevice?**
[pyaudio](https://pypi.org/project/PyAudio/) is still perfectly fine, but reasons for switching to [sounddevice](https://pypi.org/project/sounddevice/) are mainly about removing manual work during the install process, so that we can auto-install (windows basically no difference, mac no longer needs to manually install portaudio, linux mostly gets there but still has a little work) - also considering `sounddevice` is likely the better long term support as python versions upgrade.

| platform | `pyaudio` | `sounddevice` |
|---|---|---|
| Windows | wheel | wheel, portaudio inside |
| macOS | no wheel: compiler + `brew install portaudio` | wheel, portaudio inside |
| Linux | no wheel: compiler + `portaudio19-dev` | wheel + `libportaudio2` |

More `pyaudio` vs `sounddevice` info:
`pyaudio` contains C code that has to be compiled per python version (and no wheels 3.14+)
pyaudio latest release Nov 7, 2023 ([1M monthly downloads](https://pepy.tech/projects/pyaudio?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=weekly&viewType=line&versions=Total%2C0.*))

`sounddevice` is just `.py` files, no compile needed
sounddevice latest release Aug 17, 2026, ([22M monthly downloads](https://pepy.tech/projects/sounddevice?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=weekly&viewType=line&versions=Total%2C0.*))

**Testing**

Tested parrot.py upstream vs this branch in separate repos. 
Python 3.12, fresh venv in each, using `--no-cache-dir` to get a fair comparison.

QA'd Windows, macOS, Linux

- Install fresh requirements (before/after time not significant, -10s on Windows)
- record 1 mic
- Use keyboard shortcuts space, backspace, escape (found that backspace doesn't work on mac/linux, not new)
- record 2 mics
- looked at file outputs before/after and saw identical file size, gain, rate
- trained a simple 2 net AudioNet model
- Ran Analyze with new recorded samples succesfully
- Ran play.py -t successfully

Found some issues in Linux, but nothing caused by this PR. (High gain causing clipping, no 16khz sample rate mics work)

After a existing users `git pull`:
<img width="756" height="84" alt="image" src="https://github.com/user-attachments/assets/382ea73d-b161-49aa-89f2-e2fc9a632da4" />

Full QA completed checklist below

Confidence level on no regressions: high

---

<details>
<summary><b>Windows - done, all green</b></summary>
<br>

- [x] fresh venv installs with no compiler and no build tools: no `Building wheel for`, no `Microsoft Visual C++ 14.0 or greater is required`
- [x] old pyaudio venv, pulled forward: an install message, not a traceback
- [x] runs after that install

Everything below ran in the sounddevice clone.

### Mic list (`settings.py` -> `R`)

- [x] every mic listed, with its sound backend
- [x] one `DEFAULT`, and it is the real default
- [x] empty input records from the default
- [x] a number no mic has is refused, no crash
- [x] same index means the same mic on both sides, no drift

### Record

- [x] counter moves on sound, sits still on silence
- [x] wav length matches wall clock
- [x] normal pitch, no crackle, no stutter
- [x] first sound not cut off
- [x] `SPACE` pauses, and nothing said while paused is in the wav
- [x] resume leaves no glitch at the seam
- [x] `BACKSPACE` drops about 3 seconds
- [x] two mics at once: two wavs, same length, aligned
- [x] compare files for pyaudio vs sounddevice

<img width="717" height="504" alt="image" src="https://github.com/user-attachments/assets/24ed4f27-e029-4f70-9d2c-e7d33b5ef849" />
<img width="719" height="506" alt="image" src="https://github.com/user-attachments/assets/a06582ca-3c75-4f1e-a3a7-9c18bf8e679d" />

### Listen (`play.py -t`)

- [x] detects
- [x] `SPACE` pauses and resumes
- [x] `ESC` exits clean, no hang

**Unplug / replug: inconclusive, not a regression.**

Tested with a Bluetooth headset. On disconnect, both pyaudio and sounddevice fell through to the next available recording device instead of stalling, so the stall-and-retry path never ran on either side. Windows always has another input to fall back to, so a Bluetooth drop cannot produce the no-device state this test assumes.

To actually exercise it: a USB mic pinned via `INPUT_DEVICE_INDEX` rather than `DEFAULT`, then unplugged so nothing inherits its index. Not done.

Separate from this PR, but noted: silently switching to a different mic mid-listen is its own problem, and it behaves the same before and after.

### No mic connected

- [x] record menu: empty list, clean exit
- [x] `play.py`: no-microphone message, not a traceback

### Analyze (`settings.py` -> `A` -> `n`)

- [x] prints the mic name and continues

### Not covered

`play.py -c dummy` cannot run on either side. `DummyClassifier` has no `get_setting`, and `lib/listen.py` calls it in 12 places. Pre-existing at 3da01ee, unrelated to this change.

</details>

<details>
<summary><b>macOS - done, one box open: BACKSPACE is posix-only</b></summary>
<br>

The platform this PR is for. macOS 14.7.4 arm64, Homebrew already there, no portaudio, no Python 3.12. Command line tools were already installed, so `xcode-select --install` never got timed.

Order matters: phase 1 before portaudio exists, and phase 3 before phase 2.

### Phase 0 - Python 3.12

Two lines of `docs/MAC_INSTALLATION.md` are broken. Neither is this PR's doing, but the `six` one is in a file it already rewrites:

- `brew install python@3.12` aborts with `xz: no bottle available!`. macOS 14 is Tier 3 in Homebrew now. `brew install --build-from-source xz` first, 24s.
- `brew install six` fails, formula disabled 2025-10-16. pip pulls six in anyway, so the line is gone.

### Phase 1 - pyaudio, nothing installed

- [x] pyaudio fails to build: `fatal error: 'portaudio.h' file not found`

```
src/pyaudio/device_api.c:9:10: fatal error: 'portaudio.h' file not found
error: failed-wheel-build-for-install
`-> pyaudio
```

1:22 to get there, and the venv ends up holding nothing but pip. pip builds every wheel before installing any, so one missing header rolls numpy and torch back too.

clang ran, so this is the library missing, not the toolchain.

### Phase 2 - pyaudio, after `brew install portaudio`

- [x] pyaudio installs once portaudio is present
- [x] `python settings.py` opens the menu

1:40.37. portaudio poured from a bottle in seconds, so portaudio is not the slow part, needing Homebrew is.

The venv is not self-contained either:

```
$ otool -L .venv/.../pyaudio/_portaudio.cpython-312-darwin.so
    /opt/homebrew/opt/portaudio/lib/libportaudio.2.dylib
```

Uninstall portaudio and it stops importing. sounddevice keeps its dylib in site-packages.

### Phase 3 - sounddevice, run before phase 2 while the machine has no portaudio

- [x] installs with no compiler and no Homebrew portaudio
- [x] `python settings.py` opens the menu

1:40.14, no compile, portaudio still not on the machine, 1.2 GB venv. `libportaudio.dylib` ships in the wheel at `_sounddevice_data/portaudio-binaries/`.

Two things that look like regressions and are not:

- first `settings.py` launch ~25s, 1.08s every launch after. torch's dylibs, same either side.
- `resource_tracker: There appear to be 1 leaked shared_memory objects` on exit. pyaudio does it too, and it fires on a run that opens no stream at all. IPC, not audio.

### Pre-existing: training dies on an empty label

Training dies with `ZeroDivisionError` at `lib/load_data.py:175` on a label that was recorded and cancelled straight away. Untouched by this PR, same on either backend.

A fresh clone hit it in the first hour. Wants its own fix.

No pyaudio A/B for behaviour here. Windows covered it, and index drift is a Windows risk anyway: MME, WASAPI and DirectSound enumerate separately there, macOS has only CoreAudio.

Everything below ran in the sounddevice clone.

### Mic list (`settings.py` -> `R`)

- [x] every mic listed, with CoreAudio as the backend
- [x] one `DEFAULT`, and it is the real default
- [x] empty input records from the default
- [x] a number no mic has is refused, no crash

### Record

- [x] counter moves on sound, sits still on silence
- [x] wav length matches wall clock
- [x] normal pitch, no crackle, no stutter
- [x] first sound not cut off
- [x] `SPACE` pauses, and nothing said while paused is in the wav
- [x] resume leaves no glitch at the seam
- [ ] `BACKSPACE` drops about 3 seconds. Not testable on macOS: `record_data.py` matches `'\x08'`, a posix terminal sends `'\x7f'` for Delete. Windows-only, pre-existing, wants its own fix. `-` works
- [x] two mics at once: two wavs, same length, aligned
- [x] compare files for pyaudio vs sounddevice

<img width="538" height="751" alt="Screenshot 2026-09-12 at 8 05 11â€¯PM" src="https://github.com/user-attachments/assets/bd5922fd-3d80-47c4-9486-d62e687968a6" />

### Listen (`play.py -t`)

- [x] detects
- [x] `SPACE` pauses and resumes
- [x] `ESC` exits clean, no hang

### No mic connected

- [x] record menu: empty list, clean exit
- [x] `play.py`: no-microphone message, not a traceback

If you unplug a Bluetooth mic here, expect the same fall-through to another device seen on Windows. Use a USB mic pinned by `INPUT_DEVICE_INDEX` if you want the no-device path.

### Analyze (`settings.py` -> `A` -> `n`)

- [x] prints the mic name and continues

### macOS only

- [x] mic permission prompt appears on first record, and recording works after granting it
- [x] built-in mic and a USB or Bluetooth mic both enumerate
- [x] `docs/MAC_INSTALLATION.md` as rewritten here works start to finish, with no portaudio step. The `xz` bottle snag is Homebrew's, left alone

</details>

<details>
<summary><b>Linux - install and record done, listen / no mic / analyze not run</b></summary>
<br>

Ubuntu 24.04.4 LTS, x86_64, ThinkPad T480s, real hardware not WSL, X11, PipeWire. Python 3.12.3 from the distro, so no deadsnakes. No portaudio of any kind at the start.

`build-essential` and gcc 13.3 were already installed, so this machine cannot show "no compiler needed" either. What it shows is "no portaudio needed".

### Phase 0 - prerequisites

Three packages no doc names. All pre-existing, none this PR's doing:

- `python3.12-venv` - Ubuntu splits `ensurepip` out, so `python3.12 -m venv` fails until it is installed
- `python3-tk` - **a hard blocker**. `mouseinfo/__init__.py:280` calls `sys.exit()` at import, so `import pyautogui` kills the process and `settings.py` will not start at all. Bare exit, no traceback. pyautogui has been in `requirements-posix.txt` since 2021-03-26
- `python3.12-dev` - pyaudio only. sounddevice does not need it, so the migration removes it

`docs/LINUX_INSTALLATION.md` names 'TK' without naming the package. Fixed here: name `python3-tk` the way the line already names `libportaudio2`.

### Phase 1 - pyaudio, nothing installed

- [x] fails, but **not** the way macOS did. It never reaches portaudio

```
src/pyaudio/device_api.h:7:10: fatal error: Python.h: No such file or directory
Failed to build pyaudio
error: failed-wheel-build-for-install
```

- [x] venv left holding nothing but pip, 13 MB

14m16 to get there. gcc ran, so this is a missing header, not a missing toolchain.

Not re-run after installing the headers, deliberately: phase 3 has to run on a machine given nothing on pyaudio's behalf.

### Phase 3 - sounddevice, before installing anything portaudio

- [x] `pip install` succeeds with no `libportaudio2` present, and nothing compiles
- [x] `settings.py` before `libportaudio2`: the error below
- [x] `settings.py` after `libportaudio2`: opens, enumerates 14 devices
- [x] timed both

15m52, zero build attempts for sounddevice. Unlike macOS the wheel carries no portaudio, so this is what a Linux user sees first:

```
sounddevice could not load PortAudio: PortAudio library not found
On Debian and Ubuntu: sudo apt-get install libportaudio2
```

Two lines, names the fix, no traceback. `sudo apt install libportaudio2` is seconds.

### Phase 2 - pyaudio, after `portaudio19-dev`

- [x] installs once the headers exist
- [x] `settings.py` opens
- [x] `build-essential` was already there

apt 11.2s for `portaudio19-dev` + `python3.12-dev`, pip 16m05.

### Install time is a wash here too

| | pyaudio | sounddevice |
|---|---|---|
| system deps | `portaudio19-dev` + `python3.12-dev`, 11.2s | `libportaudio2`, seconds |
| pip install | 16m05 | 15m52 |
| without them | fails at 14m16, venv left holding pip | installs clean |
| compiles a C extension | yes | no |

Both sides are download-bound on the same ~3 GB of torch, which is why the Linux numbers are an order of magnitude above Windows and macOS. Unrelated to this PR: plain `torch` on Linux pulls the CUDA build, 2.4 GB of nvidia wheels.

### Mic list (`settings.py` -> `R`)

- [x] every mic listed, with ALSA as the backend
- [x] one `DEFAULT`, and it is the real default
- [x] a number no mic has is refused, no crash
- [x] same index means the same mic on both sides, no drift

Device lists are **byte-identical** between backends: all 14 entries, same indices, same channel counts.

Indices are positional and do shift on a replug: `default` was `[12]` with the built-in mic only, `[13]` once a USB mic was added.

### Raw ALSA devices cannot record, and the menu offers them

The one real Linux finding. `RATE = 16000`, and no consumer mic does 16 kHz natively, so the raw `hw:` entries fail outright:

```
Expression 'paInvalidSampleRate' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 2048
sounddevice.PortAudioError: Error opening InputStream: Invalid sample rate [PaErrorCode -9997]
```

Probed every input device on both backends, same machine, USB mic connected:

| device | pyaudio | sounddevice |
|---|---|---|
| `[0]` HDA Intel PCH: ALC257 Analog `hw:0,0` | fails | fails |
| `[4]` fifine Microphone: USB Audio `hw:1,0` | fails | fails |
| `[5]` sysdefault | OK | OK |
| `[11]` pipewire | OK | OK |
| `[13]` default | OK | OK |

**Identical, so not this PR's doing** - it is PortAudio's ALSA backend, below either wrapper. Windows resamples in the audio engine and macOS in CoreAudio, so neither platform can show this.

The trap is which entries have the good names: the raw devices inherit the card name and read as "fifine Microphone", while the ones that work are called `default` and `pipewire`. Worth fixing, but not here: filter to what opens at `RATE`, or catch `PortAudioError` and name the cause.

### ALSA stderr: quieter after

On device enumeration, stdout and stderr separated:

- pyaudio: 12 lines (`Unknown PCM cards.pcm.rear`, `find_matching_chmap`), plus two `JackShmReadWritePtr` lines
- sounddevice: 0

Not silent in general - the sample rate failure above prints three `Expression ... failed` lines from PortAudio itself.

### Record

Works once the input is not clipped. With the laptop's stock +60 dB gain dropped, sounddevice recorded 20.2 s at -10.2 dBFS peak, 0 clipped samples, threshold `-53.53`, 34 events, no traceback. `listen`, `no mic` and `analyze` are still not run.

- [x] compare files for pyaudio vs sounddevice - 20 s of pops in each clone, un-clipped: identical frame count (324000), same format, peak within 0.2 dB and rms within 0.5 dB. Event counts differ (34 vs 53) but these are two different takes, not one wav through both, so that is not a backend difference

**The crash reproduces identically under pyaudio**, so it is not this PR's doing:

```
File "lib/stream_processing.py", line 380, in post_processing
    frame.label = current_label.label
AttributeError: 'NoneType' object has no attribute 'label'
```

`lib/stream_processing.py` is byte-identical on both branches, and the failure was reproduced on both, so it is not a regression. Cause: a stock Ubuntu install on this laptop ships +60 dB on the internal mic (`Capture` 30 dB plus `Internal Mic Boost` 30 dB), every sample pinned to full scale. A clipped signal reads above 0 dBFS, the threshold lands at `+0.63`, `dBFS >= threshold` is never true again, and `current_label` is never assigned while `detected` is already true from the live pass. Wants its own fix, not this PR's.

### Not run on Linux

- [ ] `listen` (`play.py -t`) - needs a trained model first
- [ ] no mic connected: record menu, and `play.py`
- [ ] `analyze` (`settings.py` -> `A` -> `n`)
- [ ] two mics at once. May be impossible here: the only devices that accept 16 kHz are `sysdefault`, `pipewire` and `default`, and they all point at the same source
- [ ] the per-take record checks: `SPACE` pause and resume, `-` dropping 3 s, first sound not cut off
- [ ] `docs/LINUX_INSTALLATION.md` start to finish. Already known to break in three places on 24.04, none of them audio, so it wants its own PR

</details>

